### PR TITLE
[Auth] 로그인 화면 구현 (Issue #4)

### DIFF
--- a/src/app/(auth)/login/actions.ts
+++ b/src/app/(auth)/login/actions.ts
@@ -21,7 +21,7 @@ export async function loginAction(
   password: string,
 ): Promise<LoginActionResult> {
   const baseUrl =
-    process.env.NEXT_PUBLIC_API_BASE_URL ??
+    process.env.API_BASE_URL ??
     `http://localhost:${process.env.PORT ?? 3000}`;
 
   let data: LoginResponseData;
@@ -33,6 +33,16 @@ export async function loginAction(
       body: JSON.stringify({ email, password }),
       cache: "no-store",
     });
+
+    if (!res.ok) {
+      return {
+        success: false,
+        message:
+          res.status === 401
+            ? "이메일 또는 비밀번호가 올바르지 않습니다."
+            : "서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+      };
+    }
 
     const json: ApiResponse<LoginResponseData> = await res.json();
 

--- a/src/app/(auth)/login/actions.ts
+++ b/src/app/(auth)/login/actions.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import type { AuthUser, ApiResponse } from "@/types";
+
+interface LoginResponseData {
+  accessToken: string;
+  tokenType: string;
+  expiresIn: number;
+  user: AuthUser;
+}
+
+interface LoginActionResult {
+  success: false;
+  message: string;
+}
+
+export async function loginAction(
+  email: string,
+  password: string,
+): Promise<LoginActionResult> {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_API_BASE_URL ??
+    `http://localhost:${process.env.PORT ?? 3000}`;
+
+  let data: LoginResponseData;
+
+  try {
+    const res = await fetch(`${baseUrl}/api/v1/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+      cache: "no-store",
+    });
+
+    const json: ApiResponse<LoginResponseData> = await res.json();
+
+    if (!json.success) {
+      return {
+        success: false,
+        message: "이메일 또는 비밀번호가 올바르지 않습니다.",
+      };
+    }
+
+    data = json.data;
+  } catch {
+    return {
+      success: false,
+      message: "서버와 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.",
+    };
+  }
+
+  const cookieStore = await cookies();
+  cookieStore.set("auth-token", data.accessToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: data.expiresIn,
+    path: "/",
+  });
+
+  redirect("/dashboard");
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -24,10 +24,13 @@ const loginSchema = z.object({
     .string()
     .min(1, "이메일을 입력해 주세요.")
     .email("올바른 이메일 형식이 아닙니다."),
-  password: z
-    .string()
-    .min(1, "비밀번호를 입력해 주세요.")
-    .min(8, "비밀번호는 최소 8자 이상이어야 합니다."),
+  password: z.string().superRefine((val, ctx) => {
+    if (val.length === 0) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "비밀번호를 입력해 주세요." });
+    } else if (val.length < 8) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "비밀번호는 최소 8자 이상이어야 합니다." });
+    }
+  }),
 });
 
 type LoginFormValues = z.infer<typeof loginSchema>;

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,10 +1,148 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { loginAction } from "./actions";
+
+// ── Validation schema ────────────────────────────────────────────────────────
+
+const loginSchema = z.object({
+  email: z
+    .string()
+    .min(1, "이메일을 입력해 주세요.")
+    .email("올바른 이메일 형식이 아닙니다."),
+  password: z
+    .string()
+    .min(1, "비밀번호를 입력해 주세요.")
+    .min(8, "비밀번호는 최소 8자 이상이어야 합니다."),
+});
+
+type LoginFormValues = z.infer<typeof loginSchema>;
+
+// ── Component ────────────────────────────────────────────────────────────────
+
 export default function LoginPage() {
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+  });
+
+  const onSubmit = (values: LoginFormValues) => {
+    setServerError(null);
+    startTransition(async () => {
+      const result = await loginAction(values.email, values.password);
+      // loginAction redirects on success, so result is only returned on failure
+      if (result && !result.success) {
+        setServerError(result.message);
+      }
+    });
+  };
+
   return (
-    <div className="w-full max-w-sm rounded-lg border border-gray-200 bg-white p-8 shadow-sm">
-      <h1 className="mb-6 text-center text-xl font-semibold text-gray-900">
-        영업 일일 보고 시스템
-      </h1>
-      <p className="text-center text-sm text-gray-500">로그인 화면 — Issue #4에서 구현</p>
-    </div>
+    <Card className="w-full max-w-sm shadow-md">
+      <CardHeader className="pb-4">
+        <CardTitle className="text-center text-xl font-semibold">
+          영업 일일 보고 시스템
+        </CardTitle>
+      </CardHeader>
+
+      <CardContent>
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          noValidate
+          aria-label="로그인 폼"
+        >
+          {/* Server-level error (wrong credentials etc.) */}
+          {serverError && (
+            <div
+              role="alert"
+              className="mb-4 rounded-md bg-red-50 px-3 py-2 text-sm text-red-600"
+            >
+              {serverError}
+            </div>
+          )}
+
+          {/* Email */}
+          <div className="mb-4">
+            <Label htmlFor="email" className="mb-1.5 block">
+              이메일
+            </Label>
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              placeholder="hong@example.com"
+              aria-invalid={!!errors.email}
+              aria-describedby={errors.email ? "email-error" : undefined}
+              disabled={isPending}
+              {...register("email")}
+            />
+            {errors.email && (
+              <p id="email-error" className="mt-1 text-xs text-red-500">
+                {errors.email.message}
+              </p>
+            )}
+          </div>
+
+          {/* Password */}
+          <div className="mb-6">
+            <Label htmlFor="password" className="mb-1.5 block">
+              비밀번호
+            </Label>
+            <Input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              placeholder="비밀번호 (최소 8자)"
+              aria-invalid={!!errors.password}
+              aria-describedby={errors.password ? "password-error" : undefined}
+              disabled={isPending}
+              {...register("password")}
+            />
+            {errors.password && (
+              <p id="password-error" className="mt-1 text-xs text-red-500">
+                {errors.password.message}
+              </p>
+            )}
+          </div>
+
+          {/* Submit */}
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={isPending}
+            aria-label="로그인"
+          >
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                로그인 중...
+              </>
+            ) : (
+              "로그인"
+            )}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,17 +1,49 @@
-export default function MainLayout({
+import { cookies } from "next/headers";
+import { verifyToken } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { AuthProvider } from "@/lib/auth-context";
+import type { AuthUser } from "@/types";
+
+export default async function MainLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  let initialUser: AuthUser | null = null;
+
+  const cookieStore = await cookies();
+  const rawToken = cookieStore.get("auth-token")?.value;
+  if (rawToken) {
+    try {
+      const payload = verifyToken(rawToken);
+      const rep = await prisma.salesRep.findUnique({
+        where: { id: payload.sub },
+        select: { id: true, name: true, email: true, role: true },
+      });
+      if (rep) {
+        initialUser = {
+          id: rep.id,
+          name: rep.name,
+          email: rep.email,
+          role: rep.role as AuthUser["role"],
+        };
+      }
+    } catch {
+      // Invalid token — initialUser remains null
+    }
+  }
+
   return (
-    <div className="flex h-screen bg-gray-100">
-      {/* 사이드 메뉴 — Issue #5에서 구현 */}
-      <aside className="w-56 shrink-0 bg-white shadow" />
-      <div className="flex flex-1 flex-col overflow-hidden">
-        {/* 상단 네비게이션 — Issue #5에서 구현 */}
-        <header className="h-14 shrink-0 bg-white shadow-sm" />
-        <main className="flex-1 overflow-auto p-6">{children}</main>
+    <AuthProvider initialUser={initialUser}>
+      <div className="flex h-screen bg-gray-100">
+        {/* 사이드 메뉴 — Issue #5에서 구현 */}
+        <aside className="w-56 shrink-0 bg-white shadow" />
+        <div className="flex flex-1 flex-col overflow-hidden">
+          {/* 상단 네비게이션 — Issue #5에서 구현 */}
+          <header className="h-14 shrink-0 bg-white shadow-sm" />
+          <main className="flex-1 overflow-auto p-6">{children}</main>
+        </div>
       </div>
-    </div>
+    </AuthProvider>
   );
 }

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  type ReactNode,
+} from "react";
+import type { AuthUser } from "@/types";
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  setUser: (user: AuthUser | null) => void;
+  clearUser: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({
+  children,
+  initialUser = null,
+}: {
+  children: ReactNode;
+  initialUser?: AuthUser | null;
+}) {
+  const [user, setUserState] = useState<AuthUser | null>(initialUser);
+
+  const setUser = useCallback((u: AuthUser | null) => {
+    setUserState(u);
+  }, []);
+
+  const clearUser = useCallback(() => {
+    setUserState(null);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, setUser, clearUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return ctx;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -58,8 +58,16 @@ export function middleware(request: NextRequest): NextResponse {
   }
 
   // ── Page route protection ─────────────────────────────────────────────────
-  const token = request.cookies.get("auth-token")?.value ?? null;
-  const isAuthenticated = !!token;
+  let isAuthenticated = false;
+  const rawToken = request.cookies.get("auth-token")?.value;
+  if (rawToken) {
+    try {
+      verifyToken(rawToken);
+      isAuthenticated = true;
+    } catch {
+      // Invalid or expired token — treat as unauthenticated
+    }
+  }
 
   // Authenticated user accessing /login → redirect to /dashboard
   if (PUBLIC_PAGE_PATHS.has(pathname) && isAuthenticated) {
@@ -74,7 +82,11 @@ export function middleware(request: NextRequest): NextResponse {
   if (isProtected && !isAuthenticated) {
     const loginUrl = new URL("/login", request.url);
     loginUrl.searchParams.set("from", pathname);
-    return NextResponse.redirect(loginUrl);
+    const response = NextResponse.redirect(loginUrl);
+    if (rawToken) {
+      response.cookies.delete("auth-token");
+    }
+    return response;
   }
 
   return NextResponse.next();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,48 +1,93 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { verifyToken } from "@/lib/auth";
 
-const PUBLIC_PATHS = new Set(["/api/v1/auth/login", "/login"]);
+// API routes that do not require authentication
+const PUBLIC_API_PATHS = new Set(["/api/v1/auth/login"]);
+
+// Page routes that are accessible without authentication
+const PUBLIC_PAGE_PATHS = new Set(["/login"]);
+
+// Page route prefixes that require authentication
+const PROTECTED_PAGE_PREFIXES = [
+  "/dashboard",
+  "/reports",
+  "/customers",
+  "/notifications",
+  "/sales-reps",
+];
 
 export function middleware(request: NextRequest): NextResponse {
   const { pathname } = request.nextUrl;
 
-  // Allow exact public paths
-  if (PUBLIC_PATHS.has(pathname)) {
-    return NextResponse.next();
+  // ── API route protection ──────────────────────────────────────────────────
+  if (pathname.startsWith("/api/")) {
+    if (PUBLIC_API_PATHS.has(pathname)) {
+      return NextResponse.next();
+    }
+
+    const authHeader = request.headers.get("authorization");
+    const token = authHeader?.startsWith("Bearer ")
+      ? authHeader.slice(7)
+      : null;
+
+    if (!token) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: { code: "UNAUTHORIZED", message: "인증이 필요합니다." },
+        },
+        { status: 401 },
+      );
+    }
+
+    try {
+      const payload = verifyToken(token);
+      const requestHeaders = new Headers(request.headers);
+      requestHeaders.set("x-user-id", String(payload.sub));
+      requestHeaders.set("x-user-role", payload.role);
+      return NextResponse.next({ request: { headers: requestHeaders } });
+    } catch {
+      return NextResponse.json(
+        {
+          success: false,
+          error: { code: "INVALID_TOKEN", message: "유효하지 않은 토큰입니다." },
+        },
+        { status: 401 },
+      );
+    }
   }
 
-  // Only guard API routes here; page routes are guarded client-side
-  if (!pathname.startsWith("/api/")) {
-    return NextResponse.next();
+  // ── Page route protection ─────────────────────────────────────────────────
+  const token = request.cookies.get("auth-token")?.value ?? null;
+  const isAuthenticated = !!token;
+
+  // Authenticated user accessing /login → redirect to /dashboard
+  if (PUBLIC_PAGE_PATHS.has(pathname) && isAuthenticated) {
+    return NextResponse.redirect(new URL("/dashboard", request.url));
   }
 
-  const authHeader = request.headers.get("authorization");
-  const token = authHeader?.startsWith("Bearer ")
-    ? authHeader.slice(7)
-    : null;
+  // Unauthenticated user accessing a protected page → redirect to /login
+  const isProtected = PROTECTED_PAGE_PREFIXES.some((prefix) =>
+    pathname.startsWith(prefix),
+  );
 
-  if (!token) {
-    return NextResponse.json(
-      { success: false, error: { code: "UNAUTHORIZED", message: "인증이 필요합니다." } },
-      { status: 401 },
-    );
+  if (isProtected && !isAuthenticated) {
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("from", pathname);
+    return NextResponse.redirect(loginUrl);
   }
 
-  try {
-    const payload = verifyToken(token);
-    const requestHeaders = new Headers(request.headers);
-    requestHeaders.set("x-user-id", String(payload.sub));
-    requestHeaders.set("x-user-role", payload.role);
-
-    return NextResponse.next({ request: { headers: requestHeaders } });
-  } catch {
-    return NextResponse.json(
-      { success: false, error: { code: "INVALID_TOKEN", message: "유효하지 않은 토큰입니다." } },
-      { status: 401 },
-    );
-  }
+  return NextResponse.next();
 }
 
 export const config = {
-  matcher: ["/api/v1/:path*"],
+  matcher: [
+    "/api/v1/:path*",
+    "/login",
+    "/dashboard/:path*",
+    "/reports/:path*",
+    "/customers/:path*",
+    "/notifications/:path*",
+    "/sales-reps/:path*",
+  ],
 };


### PR DESCRIPTION
## Summary

- SCR-01 로그인 페이지(`/login`) 구현 — shadcn/ui Card + Input + Button, react-hook-form + Zod 폼 검증
- `loginAction` Server Action — `POST /api/v1/auth/login` 호출 후 accessToken을 httpOnly 쿠키(`auth-token`)에 저장, 성공 시 `/dashboard` 리다이렉트
- `AuthProvider` / `useAuth` Context — 전역 사용자(`AuthUser`) 상태 관리
- `src/middleware.ts` 강화 — 페이지 라우트 보호 추가 (미인증 사용자 → `/login`, 인증된 사용자의 `/login` 접근 → `/dashboard`)

## Changed Files

| 파일 | 변경 내용 |
|---|---|
| `src/app/(auth)/login/page.tsx` | 로그인 폼 UI (Client Component) |
| `src/app/(auth)/login/actions.ts` | Server Action — 로그인 API 호출 및 쿠키 설정 |
| `src/lib/auth-context.tsx` | AuthProvider + useAuth 훅 |
| `src/middleware.ts` | API 보호 유지 + 페이지 라우트 보호 추가 |

## Test plan

- [ ] 올바른 이메일/비밀번호 입력 → 로그인 → `/dashboard` 이동 확인
- [ ] 잘못된 자격증명 → 인라인 오류 메시지 표시, 페이지 유지 확인
- [ ] 빈 필드 제출 → Zod 인라인 유효성 오류 표시 확인
- [ ] 비밀번호 7자 이하 → "최소 8자" 오류 표시 확인
- [ ] 잘못된 이메일 형식 → 이메일 형식 오류 표시 확인
- [ ] 로그인 중 버튼 비활성화 + Loader2 스피너 표시 확인
- [ ] 엔터 키로 폼 제출 확인
- [ ] 인증된 상태에서 `/login` 접근 → `/dashboard` 리다이렉트 확인
- [ ] 미인증 상태에서 `/dashboard` 접근 → `/login` 리다이렉트 확인
- [ ] 모바일 뷰포트(375px)에서 Card 레이아웃 정상 표시 확인

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)